### PR TITLE
add chunk header LastEventRecOffset

### DIFF
--- a/evtx.go
+++ b/evtx.go
@@ -113,6 +113,11 @@ type ChunkHeader struct {
 	FirstEventRecID     uint64
 	LastEventRecID      uint64
 	HeaderSize          uint32
+	LastEventRecOffset  uint32
+	_                   [4]byte
+	EventRecordCheckSum uint32
+	_                   [68]byte
+	CheckSum            uint32
 }
 
 type Chunk struct {


### PR DESCRIPTION
Added the 'Last event record data offset' field to the Chunk Header because the data is present there.

Reference: https://github.com/libyal/libevtx/blob/main/documentation/Windows%20XML%20Event%20Log%20(EVTX).asciidoc#31-chunk-header

