### PR TITLE
Bugfix: numArguments cap and ConsumeUint8 bounds check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 	go build -o dumpevtx ./cmd/
 
 test:
-	go test ./...
+	go test -v ./...
 
 windows:
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc go build -o dumpevtx.exe cmd/*.go

--- a/bounds_test.go
+++ b/bounds_test.go
@@ -1,0 +1,102 @@
+package evtx
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+)
+
+// TestConsumeUint8AtBufferBoundary checks ConsumeUint8's bounds check at and
+// around the exact end of the buffer. offset == len(buff) must return 0
+// without panicking; a prior off-by-one guard (`if self.offset >
+// len(self.buff)`) let self.buff[self.offset] run once past the end there.
+func TestConsumeUint8AtBufferBoundary(t *testing.T) {
+	const buflen = 8
+
+	// The buffer is filled with a non-zero marker so the in-bounds case
+	// asserts an actual read: with a zeroed buffer every case would expect 0,
+	// and the test could not tell a correct read from a guard that bailed out
+	// and returned the zero value.
+	const marker = 0xAB
+
+	cases := []struct {
+		name   string
+		offset int
+		want   uint8
+	}{
+		{name: "last valid byte", offset: buflen - 1, want: marker},
+		{name: "exactly at end", offset: buflen, want: 0},
+		{name: "past end", offset: buflen + 1, want: 0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			chunk := &Chunk{}
+			ctx := NewParseContext(chunk)
+			ctx.buff = make([]byte, buflen)
+			for i := range ctx.buff {
+				ctx.buff[i] = marker
+			}
+			ctx.offset = c.offset
+
+			got := ctx.ConsumeUint8()
+
+			if got != c.want {
+				t.Errorf("ConsumeUint8() at offset %d = %d, want %d", c.offset, got, c.want)
+			}
+		})
+	}
+}
+
+// buildForgedTemplateInstance returns the bytes ParseTemplateInstance reads
+// for a template instance whose short_id has never been seen before (the
+// !pres branch), with the second, template-body numArguments read forged to
+// forgedNumArguments. This is the only branch reachable from a .evtx file
+// forged from scratch, since a short_id cannot be "already known" without
+// first being defined by this same branch.
+func buildForgedTemplateInstance(forgedNumArguments uint32) []byte {
+	buf := make([]byte, 40)
+	buf[0] = 0x01
+	binary.LittleEndian.PutUint32(buf[1:], 1) // short_id
+	// buf[5:9]: template_definition_data, unused by this test.
+	binary.LittleEndian.PutUint32(buf[9:], 5) // numArguments, 1st read: irrelevant.
+	// buf[13:29]: 16-byte long GUID, skipped since short_id is not yet known.
+	binary.LittleEndian.PutUint32(buf[29:], 0) // templateBodyLen = 0.
+	binary.LittleEndian.PutUint32(buf[33:], forgedNumArguments)
+	return buf
+}
+
+// TestParseTemplateInstanceCapsForgedNumArguments checks that a forged
+// numArguments reaching the arg-header loop through the !pres branch cannot
+// drive an unbounded number of append iterations. A cap that only applies to
+// the first (fast-path) read of numArguments does not protect this branch,
+// since it overwrites numArguments with a second, uncapped read.
+func TestParseTemplateInstanceCapsForgedNumArguments(t *testing.T) {
+	cases := []struct {
+		name            string
+		forgedArguments uint32
+	}{
+		{name: "near uint32 max", forgedArguments: 0xFFFFFFFE},
+		{name: "just above the cap", forgedArguments: maxTemplateArguments + 1},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			chunk := &Chunk{}
+			ctx := NewParseContext(chunk)
+			ctx.buff = buildForgedTemplateInstance(c.forgedArguments)
+
+			done := make(chan bool, 1)
+			go func() {
+				done <- ParseTemplateInstance(ctx)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Fatalf("ParseTemplateInstance did not return within 3s on a forged "+
+					"numArguments=%#x via the !pres branch", c.forgedArguments)
+			}
+		})
+	}
+}

--- a/evtx.go
+++ b/evtx.go
@@ -31,6 +31,13 @@ import (
 	errors "github.com/pkg/errors"
 )
 
+// maxTemplateArguments caps how many template-instance arguments
+// ParseTemplateInstance will iterate over. numArguments is read from the
+// stream as an attacker-controlled uint32 (up to ~4.29e9); this bounds the
+// resulting append loop regardless of which of the two read sites produced
+// the value.
+const maxTemplateArguments = 1024 * 10
+
 const (
 	EVTX_HEADER_MAGIC       = "ElfFile\x00"
 	EVTX_CHUNK_HEADER_MAGIC = "ElfChnk\x00"
@@ -362,7 +369,7 @@ func NewParseContext(chunk *Chunk) *ParseContext {
 }
 
 func (self *ParseContext) ConsumeUint8() uint8 {
-	if self.offset > len(self.buff) {
+	if self.offset+1 > len(self.buff) {
 		return 0
 	}
 	result := self.buff[self.offset]
@@ -704,9 +711,6 @@ func ParseTemplateInstance(ctx *ParseContext) bool {
 	// Template arguments should not be unreasonable here. Just cap
 	// them at a reasonable size.
 	numArguments := ctx.ConsumeUint32()
-	if numArguments > 1024*10 {
-		numArguments = 10 * 1024
-	}
 
 	debug("template id %x\n", short_id)
 
@@ -723,6 +727,17 @@ func ParseTemplateInstance(ctx *ParseContext) bool {
 		ctx.SkipBytes(templateBodyLen)
 		numArguments = ctx.ConsumeUint32()
 	}
+
+	// numArguments is read from the stream twice above (once on the fast
+	// path, once more in the !pres branch taken by any template not
+	// already known - which is every template in a file forged from
+	// scratch, since a short_id cannot be "known" without first being
+	// defined by that same branch). Capping only the first read, as a
+	// prior version of this function did, left the second read - the one
+	// a forged file actually reaches - unbounded. Cap once here, after
+	// both possible reads and before the read value is used as an
+	// append-loop bound.
+	numArguments = min(numArguments, maxTemplateArguments)
 
 	debug("ParseTemplateInstance Parse %x args @ %x\n", numArguments, ctx.Offset())
 

--- a/evtx.go
+++ b/evtx.go
@@ -737,7 +737,9 @@ func ParseTemplateInstance(ctx *ParseContext) bool {
 	// a forged file actually reaches - unbounded. Cap once here, after
 	// both possible reads and before the read value is used as an
 	// append-loop bound.
-	numArguments = min(numArguments, maxTemplateArguments)
+	if numArguments > maxTemplateArguments {
+		numArguments = maxTemplateArguments
+	}
 
 	debug("ParseTemplateInstance Parse %x args @ %x\n", numArguments, ctx.Offset())
 


### PR DESCRIPTION
Fixes #40.

Two independent bounds issues in `evtx.go`, both reachable from an untrusted
`.evtx` file (a log forged on a compromised host is a known anti-forensic
technique, so this is a real DoS surface for anyone parsing evidence):

1. `ParseTemplateInstance` reads `numArguments` from the stream twice: once on
   the fast path (known template), and again in the `!pres` branch, taken
   whenever `short_id` has not been seen before. The existing cap
   (`numArguments > 1024*10`) is only applied to the first read. It does not
   protect the second — which is the read a file forged from scratch always
   reaches, since a `short_id` cannot be "known" without first being defined by
   that same branch. An attacker-controlled `numArguments` up to ~4.29e9 then
   drives the arg-header append loop unbounded. Moved the cap to apply once,
   after both possible reads, right before the value is used as a loop bound.

2. `ConsumeUint8`'s bounds check, `if self.offset > len(self.buff)`, is off by
   one: at `offset == len(buff)` the check is false, and the following
   `self.buff[self.offset]` indexes one past the end and panics. The sibling
   `Consume*` methods already use the correct form (e.g. `ConsumeUint16`:
   `offset+2 > len(buff)`); this brings `ConsumeUint8` in line.

Added `bounds_test.go` with table-driven regression tests for both: a forged
`numArguments` reaching the arg-header loop through the `!pres` branch (checked
against both a near-`uint32` max value and a value just over the cap), and
`ConsumeUint8` at the exact end of the buffer and just past it. Both tests were
verified to fail against the unpatched code — the first times out, the second
panics with `index out of range [8] with length 8` — and to pass against the
fix.

Two notes on scope, to keep this focused on the two defects from #40:

- Not included: a related, lower-severity issue in `ConsumeBytes`, which
  allocates `make([]byte, size)` with an attacker-controlled `size` on the
  out-of-bounds path instead of returning nil like every other `Consume*`
  method. Happy to send it separately if you'd like it.
- `go test ./...` has two pre-existing failures here (`TestEvtx/TestCollector`,
  `TestEvtx/TestTemplates`); they exec a `./dumpevtx` binary that isn't built in
  my environment and fail identically on unmodified `master`. `go vet` likewise
  reports one pre-existing `unreachable code` finding at `evtx.go:1033` that is
  present on `master`. Neither is touched by this change.
