### PR TITLE
ConsumeBytes: return nil on out-of-bounds read instead of allocating the requested size

### DIFF
--- a/bounds_test.go
+++ b/bounds_test.go
@@ -48,6 +48,38 @@ func TestConsumeUint8AtBufferBoundary(t *testing.T) {
 	}
 }
 
+// TestConsumeBytesOutOfBounds checks that ConsumeBytes returns nil, rather
+// than allocating a stream-chosen size, when the requested size overruns the
+// buffer. size is read straight from the stream at several call sites (e.g.
+// an argument length), so allocating make([]byte, size) on that path lets a
+// malformed record drive an attacker-chosen allocation instead of simply
+// failing the read, as every other Consume* method already does by
+// returning its zero value.
+func TestConsumeBytesOutOfBounds(t *testing.T) {
+	cases := []struct {
+		name string
+		buff []byte
+		size int
+	}{
+		{name: "size exceeds remaining buffer", buff: make([]byte, 4), size: 5},
+		{name: "size exceeds empty buffer", buff: nil, size: 1024 * 1024 * 1024},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			chunk := &Chunk{}
+			ctx := NewParseContext(chunk)
+			ctx.buff = c.buff
+
+			got := ctx.ConsumeBytes(c.size)
+
+			if got != nil {
+				t.Errorf("ConsumeBytes(%d) = %v (len %d), want nil", c.size, got, len(got))
+			}
+		})
+	}
+}
+
 // buildForgedTemplateInstance returns the bytes ParseTemplateInstance reads
 // for a template instance whose short_id has never been seen before (the
 // !pres branch), with the second, template-body numArguments read forged to

--- a/evtx.go
+++ b/evtx.go
@@ -412,7 +412,7 @@ func (self *ParseContext) ConsumeUint64() uint64 {
 
 func (self *ParseContext) ConsumeBytes(size int) []byte {
 	if self.offset+size > len(self.buff) {
-		return make([]byte, size)
+		return nil
 	}
 
 	result := self.buff[self.offset : self.offset+size]


### PR DESCRIPTION
Follow-up to #40 / #41, covering the one item #41 deliberately left out.

`ConsumeBytes` returned `make([]byte, size)` on its out-of-bounds path. Since `size` comes straight from the stream (an argument length, a string length), a malformed record could make the parser allocate an attacker-chosen amount for a read that had already failed. It now returns `nil`, consistent with the zero value the other `Consume*` methods return when the buffer is exhausted.

Every call site was checked for nil-safety: results only flow into `bytes.NewBuffer`/`bytes.NewReader` (then `binary.Read`, which returns `io.EOF` and is already handled as an error), `UTF16LEToUTF8` (which returns early on empty input), `range`, `string(...)`, or plain assignment. No index expressions on a `ConsumeBytes` result exist in the module.

`bounds_test.go` gains `TestConsumeBytesOutOfBounds`: a size beyond the remaining buffer, and a 1 GiB request against an empty buffer, both assert a nil result (i.e. no allocation of the requested size).

`go test ./...` is unchanged from master apart from the new test (the two `dumpevtx` exec tests fail identically on master in an environment without that binary).